### PR TITLE
Update Veraison services to 8f5734c with HTTPS support and container fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Retrieve the Veraison source from GitHub.
 
 ```sh
 git clone https://github.com/veraison/services.git
-cd services && git checkout b50b67d && cd ..
+cd services && git checkout 8f5734c && cd ..
 ```
 
 You may see the following message, but it is not a problem.
 ```
-Note: switching to 'b50b67d'.
+Note: switching to '8f5734c'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
 changes and commit them, and you can discard any commits you make in this
@@ -72,7 +72,7 @@ Or undo this operation with:
 
 Turn off this advice by setting config variable advice.detachedHead to false
 
-HEAD is now at b50b67d Merge pull request #208 from aj-stein-nist/patch-1
+HEAD is now at 8f5734c Yogesh's review comments
 ```
 
 Next, start the services that will run on the host machine.
@@ -636,11 +636,11 @@ cd optee-ra
 Veraisonのソースをgithubから取り寄せます。
 ```sh
 git clone https://github.com/veraison/services.git
-cd services && git checkout b50b67d && cd ..
+cd services && git checkout 8f5734c && cd ..
 ```
 この際に下記のメッセージがでますが、問題ありません。
 ```
-Note: switching to 'b50b67d'.
+Note: switching to '8f5734c'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
 changes and commit them, and you can discard any commits you make in this
@@ -657,7 +657,7 @@ Or undo this operation with:
 
 Turn off this advice by setting config variable advice.detachedHead to false
 
-HEAD is now at b50b67d Merge pull request #208 from aj-stein-nist/patch-1
+HEAD is now at 8f5734c Yogesh's review comments
 ```
 
 次にホストマシン上で動作させるサービスを起動します。

--- a/provisoning/data/corim-psa.json
+++ b/provisoning/data/corim-psa.json
@@ -1,6 +1,4 @@
 {
   "corim-id": "5c57e8f4-46cd-421b-91c9-08cf93e13cfc",
-  "profiles": [
-    "http://arm.com/psa/iot/1"
-  ]
+  "profile": "http://arm.com/psa/iot/1"
 }

--- a/provisoning/run.sh
+++ b/provisoning/run.sh
@@ -20,9 +20,10 @@ build_endorsements() {
 
 submit_endorsements() {
     $VERAISON -- cocli corim submit \
-        --corim-file=${THIS_DIR}/data/psa-endorsements.cbor \
-        --api-server="http://provisioning-service:8888/endorsement-provisioning/v1/submit" \
-        --media-type="'application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1'"
+        --corim-file "${THIS_DIR}/data/psa-endorsements.cbor" \
+        --api-server "https://provisioning-service:9443/endorsement-provisioning/v1/submit" \
+        --media-type 'application/corim-unsigned+cbor; profile="http://arm.com/psa/iot/1"' \
+        --insecure
 }
 
 build_endorsements

--- a/relying_party/app/main.go
+++ b/relying_party/app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,7 @@ import (
 )
 
 func main() {
-	targetBaseURL := "http://verification-service:8080" // Base URL for the forwarding target
+	targetBaseURL := "https://verification-service:8443" // Base URL for the forwarding target
 	log.Println("Relying party is starting...")
 	server := http.Server{
 		Addr:    ":8087",
@@ -30,7 +31,11 @@ func main() {
 		}
 
 		// Create a request for the forwarding endpoint
-		client := &http.Client{}
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
 		proxyReq, err := http.NewRequest(req.Method, targetURL, req.Body)
 		if err != nil {
 			log.Printf("Error creating request: %v\n", err)

--- a/relying_party/container/Dockerfile
+++ b/relying_party/container/Dockerfile
@@ -13,12 +13,10 @@ RUN apt-get update \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Create an user
-ARG USERNAME=user
+# Use the default ubuntu user that exists in Ubuntu 24.04 (UID 1000)
+ARG USERNAME=ubuntu
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
-RUN groupadd -o --gid ${USER_GID} ${USERNAME} \
-    && useradd -o --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
 
 # Create app directory
 ENV APP_DIR=/app
@@ -28,7 +26,7 @@ RUN mkdir ${APP_DIR} \
 # Install a tool to create, verify and display EAR attestation results
 USER ${USERNAME}:${USERNAME}
 RUN go install github.com/veraison/ear/arc@latest
-ENV PATH="/home/${USERNAME}/go/bin:$PATH"
+ENV PATH="/home/${USERNAME}/go/bin:${PATH}"
 
 # Install user's tools
 USER root:root
@@ -41,4 +39,4 @@ RUN apt-get update \
 
 USER ${USERNAME}:${USERNAME}
 WORKDIR ${APP_DIR}
-ENTRYPOINT [ "bash", "-c", "make && ./rp" ]
+ENTRYPOINT make && ./rp

--- a/relying_party/container/Dockerfile
+++ b/relying_party/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
@@ -18,10 +18,10 @@ ARG USERNAME=user
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 RUN groupadd -o --gid ${USER_GID} ${USERNAME} \
-    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
+    && useradd -o --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
 
 # Create app directory
-ENV APP_DIR /app
+ENV APP_DIR=/app
 RUN mkdir ${APP_DIR} \
     && chown ${USERNAME}:${USERNAME} ${APP_DIR}
 


### PR DESCRIPTION
  ## Overview
  Update Veraison services to the latest version (8f5734c) with HTTPS support implementation and Docker container improvements.

  ## Changes

  ### 1. Veraison Services Update (9965d25)
  - **Version Update**: b50b67d → 8f5734c
  - **Ubuntu Upgrade**: 22.04 → 24.04 (for Go 1.23 support)
  - **CoRIM Profile Fix**: Changed from `profiles` array to `profile` string format
  - **Provisioning Configuration**: Updated for HTTPS API support (port 9443)
  - **Documentation**: Updated README.md with new version information

  ### 2. HTTPS Support Implementation (9a8fac1)
  - Changed verification service endpoint from HTTP:8080 to HTTPS:8443
  - Added TLS support with self-signed certificate handling
  - Imported `crypto/tls` package for secure communication

  ### 3. Docker Container Fixes (bfa8eba)
  - Resolved `arc` command PATH issue ("executable file not found in $PATH" error)
  - Simplified user configuration using default ubuntu user (UID 1000)
  - Changed ENTRYPOINT to shell form for proper environment variable expansion