### PR TITLE
Add HABv4 Secure Boot signing for i.MX8MP EVK

### DIFF
--- a/attester/container-imx/Dockerfile.yocto
+++ b/attester/container-imx/Dockerfile.yocto
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm \
     python3-subunit mesa-common-dev zstd liblz4-tool locales vim curl \
     ca-certificates gnupg file cpio bc bison flex rsync libssl-dev libncurses-dev \
-    efitools \
+    efitools u-boot-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # Check Python version (should be 3.10+ in Ubuntu 22.04)

--- a/attester/container-imx/meta-veraison-attestation/recipes-bsp/u-boot/files/hab.cfg
+++ b/attester/container-imx/meta-veraison-attestation/recipes-bsp/u-boot/files/hab.cfg
@@ -1,2 +1,3 @@
 # Enable HAB commands (hab_status) in U-Boot for i.MX8MP secure boot validation
 CONFIG_IMX_HAB=y
+CONFIG_CMD_FUSE=y

--- a/attester/container-imx/meta-veraison-attestation/recipes-bsp/u-boot/files/hab.cfg
+++ b/attester/container-imx/meta-veraison-attestation/recipes-bsp/u-boot/files/hab.cfg
@@ -1,0 +1,2 @@
+# Enable HAB commands (hab_status) in U-Boot for i.MX8MP secure boot validation
+CONFIG_IMX_HAB=y

--- a/attester/container-imx/meta-veraison-attestation/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/attester/container-imx/meta-veraison-attestation/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://hab.cfg"

--- a/attester/container-imx/secure-boot-imx8mp.sh
+++ b/attester/container-imx/secure-boot-imx8mp.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./secure-boot-imx8mp.sh [options]
+
+Options:
+  --yocto-dir PATH   Yocto directory (default: ./yocto)
+  --cst-tar PATH     CST tarball path (e.g., cst-3.1.0.tgz)
+  --cst-dir PATH     CST directory (already extracted)
+  --out-dir PATH     Output directory (default: ./secure-boot-out)
+  --pass PASS        CST key passphrase (default: test)
+  --patch-wic PATH   Patch WIC image with signed imx-boot + Image (optional)
+  -h, --help         Show this help
+
+Notes:
+  - This script orchestrates:
+      1) sign imx-boot
+      2) sign kernel Image
+      3) patch WIC (optional)
+USAGE
+}
+
+YOCTO_DIR="${YOCTO_DIR:-${SCRIPT_DIR}/yocto}"
+CST_TARBALL=""
+CST_DIR=""
+OUT_DIR="${SCRIPT_DIR}/secure-boot-out"
+CST_PASS="test"
+PATCH_WIC=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yocto-dir)
+      YOCTO_DIR="$2"; shift 2;;
+    --cst-tar)
+      CST_TARBALL="$2"; shift 2;;
+    --cst-dir)
+      CST_DIR="$2"; shift 2;;
+    --out-dir)
+      OUT_DIR="$2"; shift 2;;
+    --pass)
+      CST_PASS="$2"; shift 2;;
+    --patch-wic)
+      PATCH_WIC="$2"; shift 2;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage; exit 1;;
+  esac
+  done
+
+if [ -z "$CST_TARBALL" ] && [ -z "$CST_DIR" ]; then
+  echo "Error: --cst-tar or --cst-dir is required." >&2
+  exit 1
+fi
+
+SIGN_IMX_BOOT="$SCRIPT_DIR/secure-boot-sign-imx-boot.sh"
+SIGN_KERNEL="$SCRIPT_DIR/secure-boot-sign-kernel.sh"
+PATCH_WIC_SCRIPT="$SCRIPT_DIR/secure-boot-patch-wic.sh"
+
+"$SIGN_IMX_BOOT" \
+  --yocto-dir "$YOCTO_DIR" \
+  ${CST_TARBALL:+--cst-tar "$CST_TARBALL"} \
+  ${CST_DIR:+--cst-dir "$CST_DIR"} \
+  --out-dir "$OUT_DIR" \
+  --pass "$CST_PASS"
+
+"$SIGN_KERNEL" \
+  --yocto-dir "$YOCTO_DIR" \
+  ${CST_TARBALL:+--cst-tar "$CST_TARBALL"} \
+  ${CST_DIR:+--cst-dir "$CST_DIR"} \
+  --out-dir "$OUT_DIR" \
+  --pass "$CST_PASS"
+
+if [ -n "$PATCH_WIC" ]; then
+  "$PATCH_WIC_SCRIPT" \
+    --wic "$PATCH_WIC" \
+    --signed-imx-boot "$OUT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk-signed" \
+    --signed-image "$OUT_DIR/img/Image-signed" \
+    --out-dir "$OUT_DIR"
+fi

--- a/attester/container-imx/secure-boot-patch-wic.sh
+++ b/attester/container-imx/secure-boot-patch-wic.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./secure-boot-patch-wic.sh [options]
+
+Options:
+  --wic PATH            Input WIC (optionally .zst)
+  --signed-imx-boot PATH  Signed imx-boot binary
+  --signed-image PATH     Signed kernel Image (optional)
+  --out-dir PATH        Output directory (default: current)
+  -h, --help            Show this help
+
+Notes:
+  - imx-boot is written at 32KB (seek=32)
+  - Signed Image is copied into the boot partition (FAT)
+USAGE
+}
+
+WIC_PATH=""
+SIGNED_IMX_BOOT=""
+SIGNED_IMAGE=""
+OUT_DIR="."
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --wic)
+      WIC_PATH="$2"; shift 2;;
+    --signed-imx-boot)
+      SIGNED_IMX_BOOT="$2"; shift 2;;
+    --signed-image)
+      SIGNED_IMAGE="$2"; shift 2;;
+    --out-dir)
+      OUT_DIR="$2"; shift 2;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage; exit 1;;
+  esac
+  done
+
+if [ -z "$WIC_PATH" ] || [ -z "$SIGNED_IMX_BOOT" ]; then
+  echo "Error: --wic and --signed-imx-boot are required." >&2
+  exit 1
+fi
+
+if [ ! -f "$WIC_PATH" ]; then
+  echo "Error: WIC not found: $WIC_PATH" >&2
+  exit 1
+fi
+
+if [ ! -f "$SIGNED_IMX_BOOT" ]; then
+  echo "Error: signed imx-boot not found: $SIGNED_IMX_BOOT" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+WIC_BASE="$OUT_DIR/$(basename "$WIC_PATH")"
+cp "$WIC_PATH" "$WIC_BASE"
+
+if [[ "$WIC_BASE" == *.zst ]]; then
+  zstd -df --rm "$WIC_BASE"
+  WIC_RAW="${WIC_BASE%.zst}"
+else
+  WIC_RAW="$WIC_BASE"
+fi
+
+# Patch imx-boot at 32KB
+
+dd if="$SIGNED_IMX_BOOT" of="$WIC_RAW" bs=1024 seek=32 conv=notrunc status=progress
+
+# Patch kernel Image into boot partition
+if [ -n "$SIGNED_IMAGE" ] && [ -f "$SIGNED_IMAGE" ]; then
+  BOOT_OFFSET=$(parted -sm "$WIC_RAW" unit B print | awk -F: '$1==1 {gsub("B","",$2); print $2; exit}')
+  if [ -z "$BOOT_OFFSET" ]; then
+    echo "Warning: failed to detect boot partition offset; kernel not patched" >&2
+  else
+    MNT_DIR=$(mktemp -d)
+    sudo mount -o loop,offset="$BOOT_OFFSET" "$WIC_RAW" "$MNT_DIR"
+    sudo cp "$SIGNED_IMAGE" "$MNT_DIR/Image"
+    sync
+    sudo umount "$MNT_DIR"
+    rmdir "$MNT_DIR"
+    echo "Patched kernel Image in boot partition"
+  fi
+fi
+
+if [[ "$WIC_PATH" == *.zst ]]; then
+  zstd -f "$WIC_RAW"
+  echo "Patched WIC: ${WIC_RAW}.zst"
+else
+  echo "Patched WIC: $WIC_RAW"
+fi

--- a/attester/container-imx/secure-boot-sign-imx-boot.sh
+++ b/attester/container-imx/secure-boot-sign-imx-boot.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./secure-boot-sign-imx-boot.sh [options]
+
+Options:
+  --yocto-dir PATH   Yocto directory (default: ./yocto)
+  --cst-tar PATH     CST tarball path (e.g., cst-3.1.0.tgz)
+  --cst-dir PATH     CST directory (already extracted)
+  --out-dir PATH     Output directory (default: ./secure-boot-out)
+  --pass PASS        CST key passphrase (default: test)
+  -h, --help         Show this help
+
+Notes:
+  - This signs imx-boot (SPL + FIT) only.
+  - Output: imx-boot-imx8mpevk-sd.bin-flash_evk-signed
+USAGE
+}
+
+YOCTO_DIR="${YOCTO_DIR:-${SCRIPT_DIR}/yocto}"
+CST_TARBALL=""
+CST_DIR=""
+OUT_DIR="${SCRIPT_DIR}/secure-boot-out"
+CST_PASS="test"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yocto-dir)
+      YOCTO_DIR="$2"; shift 2;;
+    --cst-tar)
+      CST_TARBALL="$2"; shift 2;;
+    --cst-dir)
+      CST_DIR="$2"; shift 2;;
+    --out-dir)
+      OUT_DIR="$2"; shift 2;;
+    --pass)
+      CST_PASS="$2"; shift 2;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage; exit 1;;
+  esac
+  done
+
+if [ -z "$CST_TARBALL" ] && [ -z "$CST_DIR" ]; then
+  echo "Error: --cst-tar or --cst-dir is required." >&2
+  exit 1
+fi
+
+IMX_BOOT_DIR="$YOCTO_DIR/build/tmp/deploy/images/imx8mpevk"
+IMX_BOOT_BIN="$IMX_BOOT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk"
+IMX_MKIMG_DIR="$YOCTO_DIR/build/tmp/work/imx8mpevk-poky-linux/imx-boot/1.0/git"
+IMX_MKIMG_SOC_DIR="$IMX_MKIMG_DIR/iMX8M"
+
+if [ ! -f "$IMX_BOOT_BIN" ]; then
+  echo "Error: imx-boot not found at $IMX_BOOT_BIN" >&2
+  echo "Run: YOCTO_DIR=$YOCTO_DIR ./yocto.sh" >&2
+  exit 1
+fi
+
+if [ ! -d "$IMX_MKIMG_SOC_DIR" ]; then
+  echo "Error: imx-mkimage directory not found at $IMX_MKIMG_SOC_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Build Docker image if needed
+if ! docker image inspect veraison-yocto-builder >/dev/null 2>&1; then
+  echo "Yocto Docker image not found; building it first..."
+  docker build -f "$SCRIPT_DIR/Dockerfile.yocto" -t veraison-yocto-builder "$SCRIPT_DIR"
+fi
+
+CST_MOUNT_ARGS=""
+if [ -n "$CST_TARBALL" ]; then
+  CST_TARBALL_ABS="$(readlink -f "$CST_TARBALL")"
+  CST_MOUNT_ARGS="-v $CST_TARBALL_ABS:/opt/cst.tar.gz:ro"
+fi
+if [ -n "$CST_DIR" ]; then
+  CST_DIR_ABS="$(readlink -f "$CST_DIR")"
+  CST_MOUNT_ARGS="$CST_MOUNT_ARGS -v $CST_DIR_ABS:/opt/cst:ro"
+fi
+
+OUT_DIR_ABS="$(readlink -f "$OUT_DIR")"
+YOCTO_DIR_ABS="$(readlink -f "$YOCTO_DIR")"
+
+# Run signing inside Docker
+set -x
+
+docker run --rm \
+  --user 0:0 \
+  -v "$YOCTO_DIR_ABS:/yocto" \
+  -v "$OUT_DIR_ABS:/out" \
+  $CST_MOUNT_ARGS \
+  -e CST_PASS="$CST_PASS" \
+  -w /out \
+  veraison-yocto-builder \
+  /bin/bash -c '
+set -euo pipefail
+
+if [ -x /opt/cst/linux64/bin/cst ]; then
+  CST_ROOT=/opt/cst
+elif [ -f /opt/cst.tar.gz ]; then
+  if [ -x /out/cst/linux64/bin/cst ]; then
+    CST_ROOT=/out/cst
+  else
+    mkdir -p /out/cst
+    tar -xf /opt/cst.tar.gz -C /out/cst --strip-components=1
+    CST_ROOT=/out/cst
+  fi
+else
+  CST_ROOT=""
+fi
+
+if [ -z "$CST_ROOT" ] || [ ! -x "$CST_ROOT/linux64/bin/cst" ]; then
+  echo "CST not found. Provide --cst-tar or --cst-dir with linux64/bin/cst" >&2
+  exit 1
+fi
+
+CST_BIN="$CST_ROOT/linux64/bin/cst"
+PKI_SCRIPT="$CST_ROOT/keys/hab4_pki_tree.sh"
+
+if [ ! -x "$PKI_SCRIPT" ]; then
+  echo "hab4_pki_tree.sh not found in CST package" >&2
+  exit 1
+fi
+
+CSF_DIR=/out/csf
+IMG_DIR=/out/img
+LOG_DIR=/out/logs
+mkdir -p "$CSF_DIR" "$IMG_DIR" "$LOG_DIR"
+
+KEY_DIR="$CST_ROOT/keys"
+CRT_DIR="$CST_ROOT/crts"
+mkdir -p "$KEY_DIR" "$CRT_DIR"
+
+# Generate PKI tree (test keys) non-interactively if missing
+if [ ! -f "$KEY_DIR/SRK_1_2_3_4_table.bin" ]; then
+  PKI_WORK="$CST_ROOT/keys"
+  printf "n\nn\n2048\n10\n4\ny\n" | (cd "$PKI_WORK" && /bin/sh "$PKI_SCRIPT")
+
+  SRK_TOOL="$CST_ROOT/linux64/bin/srktool"
+  if [ ! -x "$SRK_TOOL" ]; then
+    echo "srktool not found in CST package" >&2
+    exit 1
+  fi
+  "$SRK_TOOL" --hab_ver 4 \
+    --table "$KEY_DIR/SRK_1_2_3_4_table.bin" \
+    --efuses "$KEY_DIR/SRK_1_2_3_4_fuses.bin" \
+    --digest sha256 \
+    --certs "$CRT_DIR/SRK1_sha256_2048_65537_v3_ca_crt.pem,$CRT_DIR/SRK2_sha256_2048_65537_v3_ca_crt.pem,$CRT_DIR/SRK3_sha256_2048_65537_v3_ca_crt.pem,$CRT_DIR/SRK4_sha256_2048_65537_v3_ca_crt.pem"
+fi
+
+IMX_MKIMG_DIR=/yocto/build/tmp/work/imx8mpevk-poky-linux/imx-boot/1.0/git
+IMX_MKIMG_SOC_DIR="$IMX_MKIMG_DIR/iMX8M"
+
+# Rebuild unsigned flash.bin to capture HAB blocks
+( cd "$IMX_MKIMG_DIR" && make SOC=iMX8MP flash_spl_uboot ) >"$LOG_DIR/mkimage.log" 2>&1
+cp "$IMX_MKIMG_SOC_DIR/flash.bin" "$IMG_DIR/flash.bin"
+
+# Patch FIT hash into SPL (handles both no-FDT and FDT offsets)
+SPL_MAP="$(find /yocto/build/tmp/work/imx8mpevk-poky-linux/u-boot-imx -name u-boot-spl.map | head -n1)"
+if [ -z "$SPL_MAP" ] || [ ! -f "$SPL_MAP" ]; then
+  echo "Failed to locate u-boot-spl.map for hash patch" >&2
+  exit 1
+fi
+
+image_off_hex=$(awk "/^[[:space:]]*image_off[[:space:]]/ {print \$NF; exit}" "$LOG_DIR/mkimage.log")
+if [ -z "$image_off_hex" ]; then
+  echo "Failed to parse image_off from mkimage.log" >&2
+  exit 1
+fi
+image_off=$((image_off_hex))
+
+start_hex=$(awk "/__image_copy_start/ {print \$1; exit}" "$SPL_MAP")
+if [ -z "$start_hex" ]; then
+  start_hex=$(awk "/\\<_start\\>/ {print \$1; exit}" "$SPL_MAP")
+fi
+end_hex=$(awk "/ _end = \\./ {print \$1; exit}" "$SPL_MAP")
+if [ -z "$start_hex" ] || [ -z "$end_hex" ]; then
+  echo "Failed to parse _start/_end from $SPL_MAP" >&2
+  exit 1
+fi
+
+start_addr=$((start_hex))
+end_addr=$((end_hex))
+end_off=$((end_addr - start_addr))
+
+spl_size=$(stat -c %s "$IMX_MKIMG_SOC_DIR/u-boot-spl-ddr.bin")
+hash_off=$((image_off + spl_size - 32))
+nofdt_off=$((image_off + end_off + 0x18000))
+
+spl_dtb_dir="$(dirname "$SPL_MAP")"
+spl_dtb="$spl_dtb_dir/u-boot-spl.dtb"
+if [ ! -f "$spl_dtb" ]; then
+  echo "Failed to locate u-boot-spl.dtb for FDT size" >&2
+  exit 1
+fi
+dtb_size_hex=$(od -An -tx1 -N4 -j4 "$spl_dtb" | tr -d " \n")
+dtb_size=$((16#$dtb_size_hex))
+dtb_size=$(((dtb_size + 3) & ~3))
+fdt_off=$((image_off + end_off + dtb_size + 0x18000))
+
+dd if="$IMG_DIR/flash.bin" of="$IMG_DIR/fit-hash.bin" bs=1 skip=$hash_off count=32 status=none
+
+dd if="$IMG_DIR/fit-hash.bin" of="$IMG_DIR/flash.bin" bs=1 seek=$nofdt_off conv=notrunc status=none
+
+dd if="$IMG_DIR/fit-hash.bin" of="$IMG_DIR/flash.bin" bs=1 seek=$fdt_off conv=notrunc status=none
+
+# Extract HAB blocks and CSF offsets
+spl_block=$(awk -F: "/spl hab block/{print \$2}" "$LOG_DIR/mkimage.log" | head -n1 | xargs)
+sld_block=$(awk -F: "/sld hab block/{print \$2}" "$LOG_DIR/mkimage.log" | head -n1 | xargs)
+
+csf_off=$(awk "/Loader IMAGE:/ {seen=1; next} seen && /csf_off/ {print \$NF; exit}" "$LOG_DIR/mkimage.log")
+sld_csf_off=$(awk "/sld_csf_off/ {print \$NF; exit}" "$LOG_DIR/mkimage.log")
+
+if [ -z "$spl_block" ] || [ -z "$sld_block" ] || [ -z "$csf_off" ] || [ -z "$sld_csf_off" ]; then
+  echo "Failed to parse HAB blocks or CSF offsets. Check $LOG_DIR/mkimage.log" >&2
+  exit 1
+fi
+
+# Generate FIT HAB blocks using print_fit_hab target
+( cd "$IMX_MKIMG_DIR" && make SOC=iMX8MP print_fit_hab ) >"$LOG_DIR/fit_hab.log" 2>&1
+fit_blocks=$(awk "/^0x/ {print \$1, \$2, \$3}" "$LOG_DIR/fit_hab.log")
+if [ -z "$fit_blocks" ]; then
+  echo "Failed to parse FIT HAB blocks. Check $LOG_DIR/fit_hab.log" >&2
+  exit 1
+fi
+
+cat > "$CSF_DIR/csf_spl.txt" <<CSF_EOF
+[Header]
+Version = 4.3
+Hash Algorithm = sha256
+Engine = CAAM
+Engine Configuration = 0
+Certificate Format = X509
+Signature Format = CMS
+
+[Install SRK]
+File = "$KEY_DIR/SRK_1_2_3_4_table.bin"
+Source index = 0
+
+[Install CSFK]
+File = "$CRT_DIR/CSF1_1_sha256_2048_65537_v3_usr_crt.pem"
+
+[Authenticate CSF]
+
+[Unlock]
+Engine = CAAM
+Features = MID
+
+[Install Key]
+File = "$CRT_DIR/IMG1_1_sha256_2048_65537_v3_usr_crt.pem"
+Verification index = 0
+Target Index = 2
+
+[Authenticate Data]
+Verification index = 2
+Engine = CAAM
+Engine Configuration = 0
+Blocks = $spl_block "$IMG_DIR/flash.bin"
+CSF_EOF
+
+cat > "$CSF_DIR/csf_fit.txt" <<CSF_EOF
+[Header]
+Version = 4.3
+Hash Algorithm = sha256
+Engine = CAAM
+Engine Configuration = 0
+Certificate Format = X509
+Signature Format = CMS
+
+[Install SRK]
+File = "$KEY_DIR/SRK_1_2_3_4_table.bin"
+Source index = 0
+
+[Install CSFK]
+File = "$CRT_DIR/CSF1_1_sha256_2048_65537_v3_usr_crt.pem"
+
+[Authenticate CSF]
+
+[Install Key]
+File = "$CRT_DIR/IMG1_1_sha256_2048_65537_v3_usr_crt.pem"
+Verification index = 0
+Target Index = 2
+
+[Authenticate Data]
+Verification index = 2
+Engine = CAAM
+Engine Configuration = 0
+Blocks = $sld_block "$IMG_DIR/flash.bin", \\
+CSF_EOF
+
+fit_count=$(echo "$fit_blocks" | wc -l)
+fit_idx=0
+while read -r addr off size; do
+  fit_idx=$((fit_idx + 1))
+  if [ "$fit_idx" -lt "$fit_count" ]; then
+    echo "         $addr $off $size \"$IMG_DIR/flash.bin\", \\" >> "$CSF_DIR/csf_fit.txt"
+  else
+    echo "         $addr $off $size \"$IMG_DIR/flash.bin\"" >> "$CSF_DIR/csf_fit.txt"
+  fi
+done <<< "$fit_blocks"
+
+"$CST_BIN" -i "$CSF_DIR/csf_spl.txt" -o "$CSF_DIR/csf_spl.bin"
+"$CST_BIN" -i "$CSF_DIR/csf_fit.txt" -o "$CSF_DIR/csf_fit.bin"
+
+cp "$IMG_DIR/flash.bin" "$IMG_DIR/signed-flash.bin"
+dd if="$CSF_DIR/csf_spl.bin" of="$IMG_DIR/signed-flash.bin" bs=1 seek=$((csf_off)) conv=notrunc status=none
+
+dd if="$CSF_DIR/csf_fit.bin" of="$IMG_DIR/signed-flash.bin" bs=1 seek=$((sld_csf_off)) conv=notrunc status=none
+
+cp "$IMG_DIR/signed-flash.bin" "/out/imx-boot-imx8mpevk-sd.bin-flash_evk-signed"
+
+echo "Signed image: /out/imx-boot-imx8mpevk-sd.bin-flash_evk-signed"
+'
+
+set +x
+
+SIGNED_IMX_BOOT="$OUT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk-signed"
+if [ ! -f "$SIGNED_IMX_BOOT" ]; then
+  echo "Error: signed imx-boot not generated" >&2
+  exit 1
+fi
+
+echo "Signed imx-boot generated at: $SIGNED_IMX_BOOT"

--- a/attester/container-imx/secure-boot-sign-kernel.sh
+++ b/attester/container-imx/secure-boot-sign-kernel.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./secure-boot-sign-kernel.sh [options]
+
+Options:
+  --yocto-dir PATH   Yocto directory (default: ./yocto)
+  --cst-tar PATH     CST tarball path (e.g., cst-3.1.0.tgz)
+  --cst-dir PATH     CST directory (already extracted)
+  --out-dir PATH     Output directory (default: ./secure-boot-out)
+  --pass PASS        CST key passphrase (default: test)
+  -h, --help         Show this help
+
+Notes:
+  - This signs the kernel Image only.
+  - Output: img/Image-signed
+USAGE
+}
+
+YOCTO_DIR="${YOCTO_DIR:-${SCRIPT_DIR}/yocto}"
+CST_TARBALL=""
+CST_DIR=""
+OUT_DIR="${SCRIPT_DIR}/secure-boot-out"
+CST_PASS="test"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yocto-dir)
+      YOCTO_DIR="$2"; shift 2;;
+    --cst-tar)
+      CST_TARBALL="$2"; shift 2;;
+    --cst-dir)
+      CST_DIR="$2"; shift 2;;
+    --out-dir)
+      OUT_DIR="$2"; shift 2;;
+    --pass)
+      CST_PASS="$2"; shift 2;;
+    -h|--help)
+      usage; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage; exit 1;;
+  esac
+  done
+
+if [ -z "$CST_TARBALL" ] && [ -z "$CST_DIR" ]; then
+  echo "Error: --cst-tar or --cst-dir is required." >&2
+  exit 1
+fi
+
+KERNEL_IMAGE="$YOCTO_DIR/build/tmp/deploy/images/imx8mpevk/Image"
+if [ ! -f "$KERNEL_IMAGE" ]; then
+  echo "Error: kernel Image not found at $KERNEL_IMAGE" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Build Docker image if needed
+if ! docker image inspect veraison-yocto-builder >/dev/null 2>&1; then
+  echo "Yocto Docker image not found; building it first..."
+  docker build -f "$SCRIPT_DIR/Dockerfile.yocto" -t veraison-yocto-builder "$SCRIPT_DIR"
+fi
+
+CST_MOUNT_ARGS=""
+if [ -n "$CST_TARBALL" ]; then
+  CST_TARBALL_ABS="$(readlink -f "$CST_TARBALL")"
+  CST_MOUNT_ARGS="-v $CST_TARBALL_ABS:/opt/cst.tar.gz:ro"
+fi
+if [ -n "$CST_DIR" ]; then
+  CST_DIR_ABS="$(readlink -f "$CST_DIR")"
+  CST_MOUNT_ARGS="$CST_MOUNT_ARGS -v $CST_DIR_ABS:/opt/cst:ro"
+fi
+
+OUT_DIR_ABS="$(readlink -f "$OUT_DIR")"
+YOCTO_DIR_ABS="$(readlink -f "$YOCTO_DIR")"
+
+set -x
+
+docker run --rm \
+  --user 0:0 \
+  -v "$YOCTO_DIR_ABS:/yocto" \
+  -v "$OUT_DIR_ABS:/out" \
+  $CST_MOUNT_ARGS \
+  -e CST_PASS="$CST_PASS" \
+  -w /out \
+  veraison-yocto-builder \
+  /bin/bash -c '
+set -euo pipefail
+
+if [ -x /opt/cst/linux64/bin/cst ]; then
+  CST_ROOT=/opt/cst
+elif [ -f /opt/cst.tar.gz ]; then
+  if [ -x /out/cst/linux64/bin/cst ]; then
+    CST_ROOT=/out/cst
+  else
+    mkdir -p /out/cst
+    tar -xf /opt/cst.tar.gz -C /out/cst --strip-components=1
+    CST_ROOT=/out/cst
+  fi
+else
+  CST_ROOT=""
+fi
+
+if [ -z "$CST_ROOT" ] || [ ! -x "$CST_ROOT/linux64/bin/cst" ]; then
+  echo "CST not found. Provide --cst-tar or --cst-dir with linux64/bin/cst" >&2
+  exit 1
+fi
+
+CST_BIN="$CST_ROOT/linux64/bin/cst"
+CSF_DIR=/out/csf
+IMG_DIR=/out/img
+mkdir -p "$CSF_DIR" "$IMG_DIR"
+
+KEY_DIR="$CST_ROOT/keys"
+CRT_DIR="$CST_ROOT/crts"
+mkdir -p "$KEY_DIR" "$CRT_DIR"
+
+KERNEL_IMAGE=/yocto/build/tmp/deploy/images/imx8mpevk/Image
+cp "$KERNEL_IMAGE" "$IMG_DIR/Image"
+raw_size=$(stat -c %s "$IMG_DIR/Image")
+image_size=$(python3 - <<PY
+import struct
+with open("$IMG_DIR/Image","rb") as f:
+    hdr=f.read(64)
+    if len(hdr) < 64:
+        print(0)
+    else:
+        fields=struct.unpack("<IIQQQQQQII", hdr)
+        print(fields[3])
+PY
+)
+if [ "$image_size" -le 0 ]; then
+  image_size="$raw_size"
+elif [ "$image_size" -lt "$raw_size" ]; then
+  image_size="$raw_size"
+fi
+
+ivt_offset=$(((image_size + 0xFFF) & ~0xFFF))
+load_addr=0x40400000
+
+cp "$IMG_DIR/Image" "$IMG_DIR/Image.pad"
+truncate -s "$((ivt_offset + 0x20))" "$IMG_DIR/Image.pad"
+
+python3 - "$IMG_DIR/Image.pad" "$ivt_offset" "$load_addr" "$image_size" <<PY
+import struct
+import sys
+
+out_path = sys.argv[1]
+ivt_offset = int(sys.argv[2], 0)
+load_addr = int(sys.argv[3], 0)
+image_size = int(sys.argv[4], 0)
+boot_data_off = ivt_offset - 0x20
+boot_data_addr = load_addr + boot_data_off
+
+hdr = struct.pack(">BHB", 0xD1, 0x20, 0x41)
+ivt = hdr + struct.pack(
+    "<7I",
+    load_addr,  # entry
+    0,          # reserved1
+    0,          # dcd
+    boot_data_addr,  # boot_data
+    load_addr + ivt_offset,         # self
+    load_addr + ivt_offset + 0x20,  # csf
+    0,          # reserved2
+)
+
+with open(out_path, "r+b") as f:
+    f.seek(boot_data_off)
+    f.write(struct.pack("<3I", load_addr, image_size, 0))
+    f.seek(ivt_offset)
+    f.write(ivt)
+PY
+
+kernel_block_size=$(printf "0x%x" "$((ivt_offset + 0x20))")
+
+cat > "$CSF_DIR/csf_kernel.txt" <<CSF_EOF
+[Header]
+Version = 4.3
+Hash Algorithm = sha256
+Engine = CAAM
+Engine Configuration = 0
+Certificate Format = X509
+Signature Format = CMS
+
+[Install SRK]
+File = "$KEY_DIR/SRK_1_2_3_4_table.bin"
+Source index = 0
+
+[Install CSFK]
+File = "$CRT_DIR/CSF1_1_sha256_2048_65537_v3_usr_crt.pem"
+
+[Authenticate CSF]
+
+[Install Key]
+File = "$CRT_DIR/IMG1_1_sha256_2048_65537_v3_usr_crt.pem"
+Verification index = 0
+Target Index = 2
+
+[Authenticate Data]
+Verification index = 2
+Engine = CAAM
+Engine Configuration = 0
+Blocks = $load_addr 0x0 $kernel_block_size "$IMG_DIR/Image.pad"
+CSF_EOF
+
+"$CST_BIN" -i "$CSF_DIR/csf_kernel.txt" -o "$CSF_DIR/csf_kernel.bin"
+
+# Append CSF (pad to 8KB)
+csf_pad="$CSF_DIR/csf_kernel.pad"
+dd if=/dev/zero of="$csf_pad" bs=1 count=$((0x2000)) status=none
+
+dd if="$CSF_DIR/csf_kernel.bin" of="$csf_pad" conv=notrunc status=none
+
+cp "$IMG_DIR/Image.pad" "$IMG_DIR/Image-signed"
+
+dd if="$csf_pad" of="$IMG_DIR/Image-signed" bs=1 seek=$((ivt_offset + 0x20)) conv=notrunc status=none
+
+echo "Signed kernel: /out/img/Image-signed"
+'
+
+set +x
+
+SIGNED_KERNEL="$OUT_DIR/img/Image-signed"
+if [ ! -f "$SIGNED_KERNEL" ]; then
+  echo "Error: signed kernel not generated" >&2
+  exit 1
+fi
+
+echo "Signed kernel generated at: $SIGNED_KERNEL"

--- a/docs/secure-boot-imx8mp-j.md
+++ b/docs/secure-boot-imx8mp-j.md
@@ -1,0 +1,200 @@
+# Secure Boot（i.MX8MP EVK / HABv4 / SD起動）
+
+このドキュメントは i.MX8MP EVK の HABv4 Secure Boot を、
+NXPのHABv4手順（SRK/CSF/Authenticate Data）と i.MX8M の
+ブートイメージ形式に沿って再現可能に行う手順です。
+署名済み `imx-boot` とカーネル `Image` を作り、WIC に反映します。
+
+**ヒューズ書き込みは不可逆**です。Open での検証が完了するまで Close にしないでください。
+
+## 前提
+
+- コマンドはリポジトリのルートから実行
+- Yocto: `/dev/shm/yocto`
+- CST tarball: `./cst-3.1.0.tgz`
+- 出力先（相対）: `../optee-ra-artifacts/secure-boot`
+- SD デバイス: `/dev/sdX`（環境に合わせて置換）
+
+## 1) Yocto ビルド（初回のみ）
+
+```bash
+cd ./attester/container-imx
+YOCTO_DIR=/dev/shm/yocto ./yocto.sh
+```
+
+## 2) 署名済み imx-boot と WIC を作成
+
+```bash
+OUT_DIR=../optee-ra-artifacts/secure-boot
+OUT_WIC="$YOCTO_DIR/build/tmp/deploy/images/imx8mpevk/core-image-minimal-imx8mpevk.rootfs.wic.zst"
+
+./attester/container-imx/secure-boot-imx8mp.sh \
+  --yocto-dir /dev/shm/yocto \
+  --cst-tar ./cst-3.1.0.tgz \
+  --out-dir "$OUT_DIR" \
+  --patch-wic "$OUT_WIC"
+```
+
+生成物:
+- 署名済み imx‑boot
+  - `$OUT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk-signed`
+- 署名済み `Image`
+  - `$OUT_DIR/img/Image-signed`
+- 署名済み imx‑boot（32KB）と署名済み `Image` を反映した WIC
+  - `$OUT_DIR/core-image-minimal-imx8mpevk.rootfs.wic.zst`
+
+各ステップを個別に実行することもできます:
+
+```bash
+./attester/container-imx/secure-boot-sign-imx-boot.sh \
+  --yocto-dir /dev/shm/yocto \
+  --cst-tar ./cst-3.1.0.tgz \
+  --out-dir "$OUT_DIR"
+
+./attester/container-imx/secure-boot-sign-kernel.sh \
+  --yocto-dir /dev/shm/yocto \
+  --cst-tar ./cst-3.1.0.tgz \
+  --out-dir "$OUT_DIR"
+
+./attester/container-imx/secure-boot-patch-wic.sh \
+  --wic "$OUT_WIC" \
+  --signed-imx-boot "$OUT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk-signed" \
+  --signed-image "$OUT_DIR/img/Image-signed" \
+  --out-dir "$OUT_DIR"
+```
+
+## 3) 鍵のバックアップ（必須）
+
+CST が生成した鍵は以下にあります:
+`$OUT_DIR/cst`
+
+必ずアーカイブしてください:
+
+```bash
+sudo tar -czf "$OUT_DIR/secure-boot-keys.tar.gz" \
+  -C "$OUT_DIR" cst
+```
+
+## 4) SRK Fuse 値の抽出
+
+```bash
+hexdump -e '/4 "0x"' -e '/4 "%X""\n"' \
+  "$OUT_DIR/cst/keys/SRK_1_2_3_4_fuses.bin"
+```
+
+出力された 8 行を `fuse prog` で使います。
+
+## 5) SD へ書き込み
+
+```bash
+cd "$OUT_DIR"
+zstd -d core-image-minimal-imx8mpevk.rootfs.wic.zst
+sudo dd if=core-image-minimal-imx8mpevk.rootfs.wic of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+`/dev/sdX` は実際のデバイスに置換してください。
+
+## 6) Open での確認（U-Boot）
+
+```text
+=> hab_status
+```
+
+Open では `Secure boot disabled` のままで OK。
+
+## 7) SRK Fuse 書き込み（U-Boot）
+
+**書き込み前**:
+
+```text
+=> fuse read 6 0 4
+=> fuse read 7 0 4
+```
+
+**SRK 書き込み**（Step 4 の値に置換）:
+
+```text
+=> fuse prog 6 0 0x........
+=> fuse prog 6 1 0x........
+=> fuse prog 6 2 0x........
+=> fuse prog 6 3 0x........
+
+=> fuse prog 7 0 0x........
+=> fuse prog 7 1 0x........
+=> fuse prog 7 2 0x........
+=> fuse prog 7 3 0x........
+```
+
+**書き込み後**:
+
+```text
+=> fuse read 6 0 4
+=> fuse read 7 0 4
+```
+
+再起動:
+
+```text
+=> reset
+```
+
+## 8) Close（不可逆）
+
+Open での確認が終わってから実行:
+
+```text
+=> fuse prog 1 3 0x2000000
+```
+
+再起動後:
+
+```text
+=> hab_status
+```
+
+`Secure boot enabled` が出れば Close 完了。
+
+## 9) Remote Attestation 確認
+
+`relying-party-service` が引けない場合:
+
+```bash
+echo "192.168.8.244 relying-party-service" >> /etc/hosts
+```
+
+実行:
+
+```bash
+optee_remote_attestation --key-hex <FullKey>
+```
+
+期待値: `ear.status: "affirming"`。
+
+Secure Boot 前に生成した BlackKey を Close 後に使うと、
+`Failed to sign payload` / `TEEC_InvokeCommand failed` となり失敗するのが正常です。
+Secure Boot により CAAM の鍵文脈（MPMR/BKEK）が変わるため、古い BlackKey は無効になります。
+
+## 10) BlackKey 使い回し不可の検証（2台）
+
+両方の実機で **同じ SRK** を書き込みます。
+
+Device A:
+
+```bash
+optee_remote_attestation --generate-blackkey
+# FullKey を控える
+```
+
+Device B:
+
+```bash
+optee_remote_attestation --key-hex <FullKey-from-A>
+```
+
+期待: **失敗**（`Failed to sign payload` など）。
+
+## 注意事項
+
+- Close は不可逆です。鍵のバックアップは必須。
+- 署名済み imx‑boot は WIC の 32KB に埋め込まれます。
+- 2台検証では SRK 値を必ず揃える必要があります。

--- a/docs/secure-boot-imx8mp.md
+++ b/docs/secure-boot-imx8mp.md
@@ -1,0 +1,201 @@
+# Secure Boot (i.MX8MP EVK, HABv4, SD boot)
+
+This guide describes a reproducible secure-boot flow for i.MX8MP EVK using
+HABv4. It follows the NXP HABv4 secure boot procedure (SRK/CSF/Authenticate
+Data) and the i.MX8M boot image format. The repo helper scripts build and sign
+`imx-boot` and the kernel `Image`, then patch the WIC image.
+
+Secure boot is **irreversible** once the fuses are burned. Always validate in
+Open mode before closing the device.
+
+## Prerequisites
+
+- Run commands from the repo root
+- Yocto build directory: `/dev/shm/yocto`
+- CST tarball placed at: `./cst-3.1.0.tgz`
+- Output directory (relative): `../optee-ra-artifacts/secure-boot`
+- SD card device path (example: `/dev/sdX`)
+
+## 1) Build Yocto image (first time only)
+
+```bash
+cd ./attester/container-imx
+YOCTO_DIR=/dev/shm/yocto ./yocto.sh
+```
+
+## 2) Generate signed imx-boot and patched WIC
+
+```bash
+OUT_DIR=../optee-ra-artifacts/secure-boot
+OUT_WIC="$YOCTO_DIR/build/tmp/deploy/images/imx8mpevk/core-image-minimal-imx8mpevk.rootfs.wic.zst"
+
+./attester/container-imx/secure-boot-imx8mp.sh \
+  --yocto-dir /dev/shm/yocto \
+  --cst-tar ./cst-3.1.0.tgz \
+  --out-dir "$OUT_DIR" \
+  --patch-wic "$OUT_WIC"
+```
+
+Outputs:
+- Signed imx-boot
+  - `$OUT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk-signed`
+- Signed kernel Image
+  - `$OUT_DIR/img/Image-signed`
+- WIC with signed imx-boot injected at 32KB and signed `Image` in the boot partition
+  - `$OUT_DIR/core-image-minimal-imx8mpevk.rootfs.wic.zst`
+
+You can run the individual steps directly:
+
+```bash
+./attester/container-imx/secure-boot-sign-imx-boot.sh \
+  --yocto-dir /dev/shm/yocto \
+  --cst-tar ./cst-3.1.0.tgz \
+  --out-dir "$OUT_DIR"
+
+./attester/container-imx/secure-boot-sign-kernel.sh \
+  --yocto-dir /dev/shm/yocto \
+  --cst-tar ./cst-3.1.0.tgz \
+  --out-dir "$OUT_DIR"
+
+./attester/container-imx/secure-boot-patch-wic.sh \
+  --wic "$OUT_WIC" \
+  --signed-imx-boot "$OUT_DIR/imx-boot-imx8mpevk-sd.bin-flash_evk-signed" \
+  --signed-image "$OUT_DIR/img/Image-signed" \
+  --out-dir "$OUT_DIR"
+```
+
+## 3) Backup the signing keys (mandatory)
+
+The CST helper generates a PKI tree and SRK materials under:
+`$OUT_DIR/cst`
+
+Archive it before burning fuses:
+
+```bash
+sudo tar -czf "$OUT_DIR/secure-boot-keys.tar.gz" \
+  -C "$OUT_DIR" cst
+```
+
+## 4) Extract SRK fuse values
+
+```bash
+hexdump -e '/4 "0x"' -e '/4 "%X""\n"' \
+  "$OUT_DIR/cst/keys/SRK_1_2_3_4_fuses.bin"
+```
+
+This prints 8 lines. You will use them in `fuse prog` below.
+
+## 5) Write SD card
+
+```bash
+cd "$OUT_DIR"
+zstd -d core-image-minimal-imx8mpevk.rootfs.wic.zst
+sudo dd if=core-image-minimal-imx8mpevk.rootfs.wic of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+Replace `/dev/sdX` with the actual SD device.
+
+## 6) Open mode validation (U-Boot)
+
+```text
+=> hab_status
+```
+
+Expected: `Secure boot disabled` (Open). This is correct before closing.
+
+## 7) Program SRK fuses (U-Boot)
+
+**Before writing**:
+
+```text
+=> fuse read 6 0 4
+=> fuse read 7 0 4
+```
+
+**Write SRK hash** (replace values with the 8 lines from Step 4):
+
+```text
+=> fuse prog 6 0 0x........
+=> fuse prog 6 1 0x........
+=> fuse prog 6 2 0x........
+=> fuse prog 6 3 0x........
+
+=> fuse prog 7 0 0x........
+=> fuse prog 7 1 0x........
+=> fuse prog 7 2 0x........
+=> fuse prog 7 3 0x........
+```
+
+**After writing**:
+
+```text
+=> fuse read 6 0 4
+=> fuse read 7 0 4
+```
+
+Reboot:
+
+```text
+=> reset
+```
+
+## 8) Close the device (irreversible)
+
+Only after Open validation is complete:
+
+```text
+=> fuse prog 1 3 0x2000000
+```
+
+Then reboot and check:
+
+```text
+=> hab_status
+```
+
+Expected: `Secure boot enabled`.
+
+## 9) Remote Attestation checks
+
+If `relying-party-service` is not resolvable, add it:
+
+```bash
+echo "192.168.8.244 relying-party-service" >> /etc/hosts
+```
+
+Run attestation:
+
+```bash
+optee_remote_attestation --key-hex <FullKey>
+```
+
+Expected: `ear.status: "affirming"`.
+
+If you reuse a BlackKey generated before closing the device, attestation should fail
+(e.g. `Failed to sign payload` / `TEEC_InvokeCommand failed`). Secure Boot changes
+the CAAM key context (MPMR/BKEK), so old BlackKeys are no longer valid.
+
+## 10) BlackKey non-reuse test (two devices)
+
+Use the same SRK for both devices.
+
+Device A:
+
+```bash
+optee_remote_attestation --generate-blackkey
+# Save FullKey(hex)
+```
+
+Device B:
+
+```bash
+optee_remote_attestation --key-hex <FullKey-from-A>
+```
+
+Expected: **failure** (e.g. `Failed to sign payload`), proving BlackKey is device-bound.
+
+## Notes
+
+- Close is irreversible. Do not proceed without key backups.
+- The signed imx-boot is injected at 32KB in the WIC by the script.
+- Use the same SRK values on both devices for the non-reuse test.


### PR DESCRIPTION
## Summary
- Add HABv4 Secure Boot signing scripts for i.MX 8M Plus EVK
- Sign SPL/FIT (`imx-boot`) and kernel `Image` using NXP CST, then patch the WIC image
- Enable U-Boot `fuse` command via Yocto config fragment for SRK hash programming
- Add documentation (EN/JA) covering the full flow: build, sign, flash, fuse programming, and Close

## Changes

### Signing scripts
- `secure-boot-imx8mp.sh` — Top-level wrapper that orchestrates the full signing + WIC patching flow
- `secure-boot-sign-imx-boot.sh` — Sign SPL and FIT (imx-boot) with HABv4 CSF
- `secure-boot-sign-kernel.sh` — Sign kernel Image with HABv4 authenticate_data
- `secure-boot-patch-wic.sh` — Inject signed imx-boot (at 32KB offset) and signed Image into WIC

### Yocto config
- `u-boot-imx_%.bbappend` + `hab.cfg` — Enable `CMD_FUSE` in U-Boot for SRK fuse programming

### Documentation
- `docs/secure-boot-imx8mp.md` (EN) / `docs/secure-boot-imx8mp-j.md` (JA)
- Covers: prerequisites, signing, key backup, SD flashing, Open mode verification, SRK fuse burning, and Close procedure

## Test plan
- [x] Signed imx-boot boots correctly in Open mode
- [x] `hab_status` shows no HAB events in Open mode
- [x] SRK hash programmed and verified via `fuse read`
- [x] Device closed successfully (`Secure boot enabled`)
- [x] CAAM Black Key generation works after Close (`--generate-blackkey`)
- [x] Remote Attestation with `ear.status: "affirming"` confirmed on Closed device