### PR TITLE
attester: add PRoT software component reporting the OP-TEE OS version

### DIFF
--- a/README-j.md
+++ b/README-j.md
@@ -297,6 +297,12 @@ Attestation result:
                         "measurement-type": "ARoT",
                         "measurement-value": "Qjf7I3AQkjFoBQBbhrKrYPX/toHhnmfZeingk5oE6jA=",
                         "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs="
+                    },
+                    {
+                        "measurement-type": "PRoT",
+                        "measurement-value": "GEXvNatCVOIWXWTrDuDroAeUoynz136EUnSEp42BGhM=",
+                        "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+                        "version": "4.6.0"
                     }
                 ]
             }
@@ -314,6 +320,19 @@ Runtime Opaque [affirming]: the Attester's executing Target Environment and Atte
 Storage Opaque [affirming]: the Attester encrypts all secrets in persistent storage via using keys which are never visible outside an HSM or the Trusted Execution Environment hardware.
 Sourced Data [none]: The Evidence received is insufficient to make a conclusion.
 ```
+
+> **OP-TEE OS のバージョン(`PRoT` ソフトウェアコンポーネント)。** TA を測定する
+> `ARoT` コンポーネントに加え、evidence には `measurement-type` が `"PRoT"` の
+> 2 つ目のソフトウェアコンポーネントが含まれ、その `version` フィールドに
+> **OP-TEE OS のバージョン**(例: `"4.6.0"`)が入ります(上記参照)。
+>
+> OP-TEE OS は安定した `version` フィールドで識別します。`measurement-value` は
+> コアの不変領域(`.text` + `.rodata`)の実行時ハッシュですが、**参照値としては
+> 登録しません**。このハッシュはビルド毎に変わるためです(OP-TEE は `core_v_str`
+> にビルド日時を埋め込み、それが測定対象の `.rodata` に含まれる)。OS の完全性
+> 自体はセキュアブート(i.MX 8M Plus では HAB/SRK)が担保します。`PRoT` の参照値を
+> 登録しないため、検証側はこのコンポーネントを照合対象外として無視し、
+> `ear.status` は `affirming` のままになります。
 
 ### 6. 異なる TA からアテステーションリクエストを送信するシナリオ
 

--- a/README-j.md
+++ b/README-j.md
@@ -326,13 +326,28 @@ Sourced Data [none]: The Evidence received is insufficient to make a conclusion.
 > 2 つ目のソフトウェアコンポーネントが含まれ、その `version` フィールドに
 > **OP-TEE OS のバージョン**(例: `"4.6.0"`)が入ります(上記参照)。
 >
-> OP-TEE OS は安定した `version` フィールドで識別します。`measurement-value` は
-> コアの不変領域(`.text` + `.rodata`)の実行時ハッシュですが、**参照値としては
-> 登録しません**。このハッシュはビルド毎に変わるためです(OP-TEE は `core_v_str`
-> にビルド日時を埋め込み、それが測定対象の `.rodata` に含まれる)。OS の完全性
-> 自体はセキュアブート(i.MX 8M Plus では HAB/SRK)が担保します。`PRoT` の参照値を
-> 登録しないため、検証側はこのコンポーネントを照合対象外として無視し、
-> `ear.status` は `affirming` のままになります。
+> `measurement-value` はコアの不変領域(`.text` + `.rodata`)の実行時ハッシュで、
+> **ビルド固有**の値です(OP-TEE は `core_v_str` にビルド日時を埋め込み、それが
+> 測定対象の `.rodata` に含まれるため、OP-TEE OS を再ビルドすると変わります)。
+> そのため `PRoT` の参照値は**リリースビルドごとに登録(更新)**します。参照値は
+> イメージを起動したりコアのログレベルを上げたりしなくても、ビルド成果物から
+> [provisoning/compute-prot-refval.py](provisoning/compute-prot-refval.py) で
+> オフライン計算できます:
+>
+> ```bash
+> ./provisoning/compute-prot-refval.py path/to/tee.elf
+> ```
+>
+> 出力された `sha-256;...` ダイジェストを
+> `provisoning/data/comid-psa-refval-*.json` の `PRoT` measurement に記載して
+> プロビジョニングしてください。参照値を登録すると検証側は `PRoT` も他の
+> コンポーネントと同様に照合します: 一致するビルドなら `ear.status` は
+> `affirming` のまま、異なる OP-TEE ビルド(またはコード改変)は `warning` として
+> 検出されます。参照値を登録しない場合は、このコンポーネントは照合対象外として
+> 無視され、`ear.status` は他のコンポーネントだけで決まります。なお Yocto
+> ビルドは再現可能(`SOURCE_DATE_EPOCH` 設定済み・クリーンビルドでビルドカウンタ
+> がリセット)なので、同一ソースの再ビルドで参照値は変わりません。QEMU コンテナ
+> ビルドは非再現のため、ビルドごとに値の取り直しが必要です。
 
 ### 6. 異なる TA からアテステーションリクエストを送信するシナリオ
 

--- a/README-j.md
+++ b/README-j.md
@@ -420,7 +420,20 @@ Sourced Data [contraindicated]: Cryptographic validation of the Evidence has fai
 
 #### 6.2. provisioning で新たな TA を登録する
 
-はじめに、新たな TA のコードハッシュ値を確認します。現在、PTA に evidence 生成リクエストを送ると、secure terminal にコードハッシュ値がデバッグ用に出力される実装になっています。具体的には以下のような一行があり、`gw9v98IV8ozl5nHpsMwl9W5nGGC0bzAYMPShwvff0vY=` がコードハッシュ値を base64 エンコードした値です。
+はじめに、新たな TA のコードハッシュ値を確認します。推奨は、ビルド成果物から
+[provisoning/compute-arot-refval.py](provisoning/compute-arot-refval.py)
+で**オフライン計算**する方法です(新しい TA の `.ta` ファイルまたは ELF を渡します。実行は不要です):
+
+```bash
+./provisoning/compute-arot-refval.py path/to/<uuid>.ta
+```
+
+別の方法として、デバッグビルドでは実行時の出力からも取得できます。PTA に
+evidence 生成リクエストを送ると、secure terminal にコードハッシュ値がデバッグ用に
+出力されます。具体的には以下のような一行があり、`gw9v98IV8ozl5nHpsMwl9W5nGGC0bzAYMPShwvff0vY=`
+がコードハッシュ値を base64 エンコードした値です。(注意: i.MX の本番ビルドは
+コアログレベルが 0 のためこのデバッグ出力は得られません。実機ではオフライン計算を
+使ってください。)
 ```txt
 D/TC:? 0 cmd_get_cbor_evidence:82 b64_measurement_value: gw9v98IV8ozl5nHpsMwl9W5nGGC0bzAYMPShwvff0vY=
 ```

--- a/README-j.md
+++ b/README-j.md
@@ -347,7 +347,10 @@ Sourced Data [none]: The Evidence received is insufficient to make a conclusion.
 > 無視され、`ear.status` は他のコンポーネントだけで決まります。なお Yocto
 > ビルドは再現可能(`SOURCE_DATE_EPOCH` 設定済み・クリーンビルドでビルドカウンタ
 > がリセット)なので、同一ソースの再ビルドで参照値は変わりません。QEMU コンテナ
-> ビルドは非再現のため、ビルドごとに値の取り直しが必要です。
+> ビルドは非再現のため、ビルドごとに値の取り直しが必要です。`ARoT` の参照値も
+> 同様に、初回実行からの取得ではなく
+> [provisoning/compute-arot-refval.py](provisoning/compute-arot-refval.py)
+> (`.ta` または TA の ELF を渡す)でビルド成果物からオフライン計算できます。
 
 ### 6. 異なる TA からアテステーションリクエストを送信するシナリオ
 

--- a/README.md
+++ b/README.md
@@ -371,14 +371,30 @@ Sourced Data [none]: The Evidence received is insufficient to make a conclusion.
 > reports the **OP-TEE OS version** in its `version` field (e.g. `"4.6.0"`), as
 > shown above.
 >
-> The OP-TEE OS is identified by the stable `version` field. Its
-> `measurement-value` is a runtime hash of the immutable core (`.text` +
-> `.rodata`) and is **not** registered as a reference value: that hash is
-> build-specific (OP-TEE embeds the build timestamp in `core_v_str`, which is
-> part of the hashed `.rodata`), so it changes on every build. OS integrity is
-> rooted in secure boot (HAB/SRK on i.MX 8M Plus). Because no `PRoT` reference
-> value is provisioned, the verifier ignores this component for matching and
-> `ear.status` remains `affirming`.
+> The `measurement-value` is a runtime hash of the immutable core (`.text` +
+> `.rodata`). It is **build-specific** (OP-TEE embeds the build timestamp in
+> `core_v_str`, which is part of the hashed `.rodata`), so it changes whenever
+> the OP-TEE OS is rebuilt — and the `PRoT` reference value therefore has to
+> be (re-)registered for every released build. Compute it offline from the
+> build artifact with
+> [provisoning/compute-prot-refval.py](provisoning/compute-prot-refval.py)
+> (no need to boot the image or raise the core log level):
+>
+> ```bash
+> ./provisoning/compute-prot-refval.py path/to/tee.elf
+> ```
+>
+> Put the printed `sha-256;...` digest into the `PRoT` measurement of
+> `provisoning/data/comid-psa-refval-*.json` before provisioning. With the
+> reference value registered the verifier checks the `PRoT` component like
+> any other: a matching build keeps `ear.status` `affirming`, while a
+> different OP-TEE build (or modified code) is flagged as `warning`. If no
+> `PRoT` reference value is provisioned, the verifier ignores the component
+> and `ear.status` is decided by the other components alone. Note: Yocto
+> builds are reproducible (`SOURCE_DATE_EPOCH` is set and the build counter
+> resets on clean builds), so rebuilding identical source does not change the
+> reference value; QEMU container builds are not reproducible and need a
+> fresh value per build.
 
 
 ### 6. Scenario for Sending Attestation Requests from Different TAs

--- a/README.md
+++ b/README.md
@@ -341,6 +341,12 @@ Attestation result:
                         "measurement-type": "ARoT",
                         "measurement-value": "Qjf7I3AQkjFoBQBbhrKrYPX/toHhnmfZeingk5oE6jA=",
                         "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs="
+                    },
+                    {
+                        "measurement-type": "PRoT",
+                        "measurement-value": "GEXvNatCVOIWXWTrDuDroAeUoynz136EUnSEp42BGhM=",
+                        "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+                        "version": "4.6.0"
                     }
                 ]
             }
@@ -358,6 +364,21 @@ Runtime Opaque [affirming]: the Attester's executing Target Environment and Atte
 Storage Opaque [affirming]: the Attester encrypts all secrets in persistent storage via using keys which are never visible outside an HSM or the Trusted Execution Environment hardware.
 Sourced Data [none]: The Evidence received is insufficient to make a conclusion.
 ```
+
+> **OP-TEE OS version (the `PRoT` software component).** In addition to the
+> `ARoT` component (which measures the Trusted Application), the evidence
+> includes a second software component with `measurement-type` `"PRoT"` that
+> reports the **OP-TEE OS version** in its `version` field (e.g. `"4.6.0"`), as
+> shown above.
+>
+> The OP-TEE OS is identified by the stable `version` field. Its
+> `measurement-value` is a runtime hash of the immutable core (`.text` +
+> `.rodata`) and is **not** registered as a reference value: that hash is
+> build-specific (OP-TEE embeds the build timestamp in `core_v_str`, which is
+> part of the hashed `.rodata`), so it changes on every build. OS integrity is
+> rooted in secure boot (HAB/SRK on i.MX 8M Plus). Because no `PRoT` reference
+> value is provisioned, the verifier ignores this component for matching and
+> `ear.status` remains `affirming`.
 
 
 ### 6. Scenario for Sending Attestation Requests from Different TAs

--- a/README.md
+++ b/README.md
@@ -394,7 +394,10 @@ Sourced Data [none]: The Evidence received is insufficient to make a conclusion.
 > builds are reproducible (`SOURCE_DATE_EPOCH` is set and the build counter
 > resets on clean builds), so rebuilding identical source does not change the
 > reference value; QEMU container builds are not reproducible and need a
-> fresh value per build.
+> fresh value per build. The `ARoT` reference value can likewise be computed
+> offline from the built TA with
+> [provisoning/compute-arot-refval.py](provisoning/compute-arot-refval.py)
+> (pass the `.ta` or the TA ELF), instead of capturing it from a first run.
 
 
 ### 6. Scenario for Sending Attestation Requests from Different TAs

--- a/README.md
+++ b/README.md
@@ -470,7 +470,22 @@ Sourced Data [contraindicated]: Cryptographic validation of the Evidence has fai
 
 #### 6.2. Registering a New TA with Provisioning
 
-First, check the code hash value of the new TA. Currently, when a request to generate evidence is sent to the PTA, the code hash value is output to the secure terminal for debugging purposes. Specifically, there is a line like the one below, where `gw9v98IV8ozl5nHpsMwl9W5nGGC0bzAYMPShwvff0vY=` is the base64 encoded value of the code hash.
+First, check the code hash value of the new TA. The recommended way is to
+compute it **offline from the build artifact** with
+[provisoning/compute-arot-refval.py](provisoning/compute-arot-refval.py)
+(pass the new TA's `.ta` file or its ELF) — no run is required:
+
+```bash
+./provisoning/compute-arot-refval.py path/to/<uuid>.ta
+```
+
+Alternatively, on debug builds the same value can be captured from a run:
+when a request to generate evidence is sent to the PTA, the code hash value
+is output to the secure terminal for debugging purposes, in a line like the
+one below, where `gw9v98IV8ozl5nHpsMwl9W5nGGC0bzAYMPShwvff0vY=` is the base64
+encoded value of the code hash. (Note this debug output is unavailable on
+i.MX production builds, where the core log level is 0 — use the offline
+script there.)
 
 ```txt
 D/TC:? 0 cmd_get_cbor_evidence:82 b64_measurement_value: gw9v98IV8ozl5nHpsMwl9W5nGGC0bzAYMPShwvff0vY=

--- a/attester/.dockerignore
+++ b/attester/.dockerignore
@@ -1,2 +1,3 @@
 README.md
 container-imx/secure-boot-out/
+container-imx/yocto/

--- a/attester/.dockerignore
+++ b/attester/.dockerignore
@@ -1,1 +1,2 @@
 README.md
+container-imx/secure-boot-out/

--- a/attester/pta_remote_attestation/remote_attestation/cbor.c
+++ b/attester/pta_remote_attestation/remote_attestation/cbor.c
@@ -7,20 +7,16 @@ encode_evidence_to_cbor(const char *eat_profile, const int psa_client_id,
                         const int psa_security_lifecycle,
                         const uint8_t *psa_implementation_id,
                         size_t psa_implementation_id_len,
-                        const char *measurement_type, const uint8_t *signer_id,
-                        size_t signer_id_len, const uint8_t *psa_instance_id,
+                        const struct psa_sw_component *components,
+                        size_t num_components, const uint8_t *psa_instance_id,
                         size_t psa_instance_id_len, const uint8_t *psa_nonce,
-                        size_t psa_nonce_len, const uint8_t *measurement_value,
-                        size_t mv_len, UsefulBuf cbor_evidence_buffer) {
+                        size_t psa_nonce_len, UsefulBuf cbor_evidence_buffer) {
     /* prepare usefulbufs because qcbor only accepts them */
     UsefulBufC ubc_eat_profile = UsefulBuf_FromSZ(eat_profile);
     UsefulBufC ubc_psa_implementation_id = {psa_implementation_id,
                                             psa_implementation_id_len};
-    UsefulBufC ubc_measurement_type = UsefulBuf_FromSZ(measurement_type);
-    UsefulBufC ubc_signer_id = {signer_id, signer_id_len};
     UsefulBufC ubc_psa_instance_id = {psa_instance_id, psa_instance_id_len};
     UsefulBufC ubc_psa_nonce = {psa_nonce, psa_nonce_len};
-    UsefulBufC ubc_measurement_value = {measurement_value, mv_len};
 
     QCBOREncodeContext encode_ctx;
     QCBOREncode_Init(&encode_ctx, cbor_evidence_buffer);
@@ -44,14 +40,26 @@ encode_evidence_to_cbor(const char *eat_profile, const int psa_client_id,
 
     /* Software Components */
     QCBOREncode_OpenArrayInMapN(&encode_ctx, PSA_SW_COMPONENTS); /* [ */
-    QCBOREncode_OpenMap(&encode_ctx);                            /* { */
-    QCBOREncode_AddTextToMapN(&encode_ctx, PSA_SW_COMPONENT_MEASUREMENT_TYPE,
-                              ubc_measurement_type);
-    QCBOREncode_AddBytesToMapN(&encode_ctx, PSA_SW_COMPONENT_MEASUREMENT_VALUE,
-                               ubc_measurement_value);
-    QCBOREncode_AddBytesToMapN(&encode_ctx, PSA_SW_COMPONENT_SIGNER_ID,
-                               ubc_signer_id);
-    QCBOREncode_CloseMap(&encode_ctx);   /* } */
+    for (size_t i = 0; i < num_components; i++) {
+        const struct psa_sw_component *c = &components[i];
+        UsefulBufC ubc_measurement_value = {c->measurement_value,
+                                            c->measurement_value_len};
+        UsefulBufC ubc_signer_id = {c->signer_id, c->signer_id_len};
+
+        QCBOREncode_OpenMap(&encode_ctx);                        /* { */
+        QCBOREncode_AddTextToMapN(&encode_ctx,
+                                  PSA_SW_COMPONENT_MEASUREMENT_TYPE,
+                                  UsefulBuf_FromSZ(c->measurement_type));
+        QCBOREncode_AddBytesToMapN(&encode_ctx,
+                                   PSA_SW_COMPONENT_MEASUREMENT_VALUE,
+                                   ubc_measurement_value);
+        if (c->version)
+            QCBOREncode_AddTextToMapN(&encode_ctx, PSA_SW_COMPONENT_VERSION,
+                                      UsefulBuf_FromSZ(c->version));
+        QCBOREncode_AddBytesToMapN(&encode_ctx, PSA_SW_COMPONENT_SIGNER_ID,
+                                   ubc_signer_id);
+        QCBOREncode_CloseMap(&encode_ctx);                       /* } */
+    }
     QCBOREncode_CloseArray(&encode_ctx); /* ] */
 
     /* Nonce */

--- a/attester/pta_remote_attestation/remote_attestation/cbor.h
+++ b/attester/pta_remote_attestation/remote_attestation/cbor.h
@@ -29,16 +29,25 @@
 #define COSE_ALGORITHM_ES256               -7
 #define COSE_SIG_CONTEXT_STRING_SIGNATURE1 "Signature1"
 
+/* One PSA software component (an entry in the Software Components claim). */
+struct psa_sw_component {
+    const char *measurement_type;     /* claim 1 (text)  */
+    const uint8_t *measurement_value; /* claim 2 (bytes) */
+    size_t measurement_value_len;
+    const char *version;              /* claim 4 (text); NULL to omit */
+    const uint8_t *signer_id;         /* claim 5 (bytes) */
+    size_t signer_id_len;
+};
+
 UsefulBufC
 encode_evidence_to_cbor(const char *eat_profile, const int psa_client_id,
                         const int psa_security_lifecycle,
                         const uint8_t *psa_implementation_id,
                         size_t psa_implementation_id_len,
-                        const char *measurement_type, const uint8_t *signer_id,
-                        size_t signer_id_len, const uint8_t *psa_instance_id,
+                        const struct psa_sw_component *components,
+                        size_t num_components, const uint8_t *psa_instance_id,
                         size_t psa_instance_id_len, const uint8_t *psa_nonce,
-                        size_t psa_nonce_len, const uint8_t *measurement_value,
-                        size_t mv_len, UsefulBuf cbor_evidence_buffer);
+                        size_t psa_nonce_len, UsefulBuf cbor_evidence_buffer);
 
 UsefulBufC generate_cose(UsefulBufC ubc_cbor_evidence,
                          UsefulBuf buffer_for_cose,

--- a/attester/pta_remote_attestation/remote_attestation/hash.c
+++ b/attester/pta_remote_attestation/remote_attestation/hash.c
@@ -1,4 +1,6 @@
+#include <config.h>
 #include <crypto/crypto.h>
+#include <kernel/linker.h>
 #include <kernel/user_access.h>
 #include <kernel/user_mode_ctx.h>
 
@@ -128,5 +130,69 @@ TEE_Result get_hash_ta_memory(uint8_t *out, size_t out_sz)
     s = ts_pop_current_session();
     res = hash_regions(&uctx->vm_info, out);
     ts_push_current_session(s);
+    return res;
+}
+
+/*
+ * Hash the OP-TEE OS (core) immutable memory: code (.text) and read-only
+ * data (.rodata). This is a runtime measurement of the trusted OS and
+ * mirrors the official OP-TEE attestation PTA (cmd_hash_tee_memory).
+ *
+ * Note: this is a self-measurement; its trustworthiness is ultimately
+ * rooted in secure boot (HAB/SRK verifying the OP-TEE image at load time).
+ */
+TEE_Result get_hash_tee_memory(uint8_t *out, size_t out_sz)
+{
+    TEE_Result res = TEE_SUCCESS;
+    void *ctx = NULL;
+
+    if (out_sz < TEE_SHA256_HASH_SIZE)
+        return TEE_ERROR_SHORT_BUFFER;
+
+    res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SHA256);
+    if (res)
+        return res;
+
+    res = crypto_hash_init(ctx);
+    if (res)
+        goto out;
+
+    res = crypto_hash_update(ctx, __text_start,
+                             __text_data_start - __text_start);
+    if (res)
+        goto out;
+    res = crypto_hash_update(ctx, __text_data_end,
+                             __text_end - __text_data_end);
+    if (res)
+        goto out;
+    if (IS_ENABLED(CFG_WITH_PAGER)) {
+        res = crypto_hash_update(ctx, __text_init_start,
+                                 __text_init_end - __text_init_start);
+        if (res)
+            goto out;
+        res = crypto_hash_update(ctx, __text_pageable_start,
+                                 __text_pageable_end - __text_pageable_start);
+        if (res)
+            goto out;
+    }
+    res = crypto_hash_update(ctx, __rodata_start,
+                             __rodata_end - __rodata_start);
+    if (res)
+        goto out;
+    if (IS_ENABLED(CFG_WITH_PAGER)) {
+        res = crypto_hash_update(ctx, __rodata_init_start,
+                                 __rodata_init_end - __rodata_init_start);
+        if (res)
+            goto out;
+        res = crypto_hash_update(ctx, __rodata_pageable_start,
+                                 __rodata_pageable_end -
+                                     __rodata_pageable_start);
+        if (res)
+            goto out;
+    }
+
+    res = crypto_hash_final(ctx, out, TEE_SHA256_HASH_SIZE);
+out:
+    crypto_hash_free_ctx(ctx);
     return res;
 }

--- a/attester/pta_remote_attestation/remote_attestation/hash.h
+++ b/attester/pta_remote_attestation/remote_attestation/hash.h
@@ -5,4 +5,7 @@
 
 TEE_Result get_hash_ta_memory(uint8_t *out, size_t out_sz);
 
+/* Hash the OP-TEE OS (core) .text + .rodata into @out (>= 32 bytes). */
+TEE_Result get_hash_tee_memory(uint8_t *out, size_t out_sz);
+
 #endif /* PTA_REMOTE_ATTESTATION_TA_HASH_H */

--- a/attester/pta_remote_attestation/remote_attestation/remote_attestation.c
+++ b/attester/pta_remote_attestation/remote_attestation/remote_attestation.c
@@ -1,3 +1,4 @@
+#include <kernel/linker.h>
 #include <kernel/pseudo_ta.h>
 #include <pta_remote_attestation.h>
 
@@ -23,6 +24,8 @@
 
 #define EAT_PROFILE     "http://arm.com/psa/2.0.0"
 #define MEASURMENT_TYPE "ARoT"
+#define MEASUREMENT_TYPE_TEE_OS "PRoT"
+#define OS_VERSION_MAX_LEN      32
 #ifdef CFG_NXP_CAAM
 #define IMPLEMENTATION_ID     "imx8mp-optee-ra-0000000000000001"
 #else
@@ -107,7 +110,6 @@ static TEE_Result cmd_get_cbor_evidence(uint32_t param_types,
     TEE_Result status = TEE_SUCCESS;
 
     const char eat_profile[] = EAT_PROFILE;
-    const char measurement_type[] = MEASURMENT_TYPE;
     const uint8_t *psa_implementation_id =
         (const uint8_t *)IMPLEMENTATION_ID;
     const size_t psa_implementation_id_len = IMPLEMENTATION_ID_LEN;
@@ -119,6 +121,8 @@ static TEE_Result cmd_get_cbor_evidence(uint32_t param_types,
     uint8_t pub_y[PUBKEY_COORD_SIZE] = {0};
 
     uint8_t measurement_value[TEE_SHA256_HASH_SIZE] = {0};
+    uint8_t tee_measurement[TEE_SHA256_HASH_SIZE] = {0};
+    char os_version[OS_VERSION_MAX_LEN] = {0};
     size_t b64_measurement_value_len = TEE_SHA256_HASH_SIZE * 2;
     char b64_measurement_value[TEE_SHA256_HASH_SIZE * 2] = {0};
 
@@ -216,6 +220,45 @@ static TEE_Result cmd_get_cbor_evidence(uint32_t param_types,
     b64_measurement_value[b64_measurement_value_len] = '\0';
     DMSG("b64_measurement_value: %s", b64_measurement_value);
 
+    /* Measure the OP-TEE OS (core .text + .rodata) for the PRoT component */
+    status = get_hash_tee_memory(tee_measurement, TEE_SHA256_HASH_SIZE);
+    if (status != TEE_SUCCESS)
+        return status;
+
+    /*
+     * OP-TEE OS version: first whitespace-delimited token of core_v_str,
+     * e.g. "4.6.0" (the build banner is "<ver> (<cc>) #<n> <date> <arch>").
+     */
+    {
+        size_t i = 0;
+
+        while (i < sizeof(os_version) - 1 && core_v_str[i] &&
+               core_v_str[i] != ' ') {
+            os_version[i] = core_v_str[i];
+            i++;
+        }
+        os_version[i] = '\0';
+        if (os_version[0] == '\0')
+            memcpy(os_version, "unknown", sizeof("unknown"));
+    }
+    DMSG("OP-TEE OS version: %s", os_version);
+
+    /*
+     * For provisioning: log the PRoT (OP-TEE OS) measurement in base64 so it
+     * can be captured once from a device boot and registered as the Veraison
+     * reference value (psa.refval-id label "PRoT").
+     */
+    {
+        size_t b64_tee_len = TEE_SHA256_HASH_SIZE * 2;
+        char b64_tee[TEE_SHA256_HASH_SIZE * 2] = {0};
+
+        if (base64_encode(tee_measurement, TEE_SHA256_HASH_SIZE, b64_tee,
+                          &b64_tee_len) == 1) {
+            b64_tee[b64_tee_len] = '\0';
+            DMSG("PRoT (OP-TEE OS) measurement-value b64: %s", b64_tee);
+        }
+    }
+
     /* Allocate CBOR/COSE work buffers on heap to avoid PTA stack overflow */
     void *heap_cbor = malloc(512);
     void *heap_cose = malloc(512);
@@ -227,12 +270,32 @@ static TEE_Result cmd_get_cbor_evidence(uint32_t param_types,
     UsefulBuf buffuer_for_cbor = {heap_cbor, 512};
     UsefulBuf buffer_for_cose = {heap_cose, 512};
 
+    /* Build the Software Components: ARoT (this TA) + PRoT (OP-TEE OS) */
+    struct psa_sw_component components[] = {
+        {
+            .measurement_type = MEASURMENT_TYPE,
+            .measurement_value = measurement_value,
+            .measurement_value_len = TEE_SHA256_HASH_SIZE,
+            .version = NULL,
+            .signer_id = signer_id,
+            .signer_id_len = SIGNER_ID_LEN,
+        },
+        {
+            .measurement_type = MEASUREMENT_TYPE_TEE_OS,
+            .measurement_value = tee_measurement,
+            .measurement_value_len = TEE_SHA256_HASH_SIZE,
+            .version = os_version,
+            .signer_id = signer_id,
+            .signer_id_len = SIGNER_ID_LEN,
+        },
+    };
+
     /* Encode evidence to CBOR */
     UsefulBufC ubc_cbor_evidence = encode_evidence_to_cbor(
         eat_profile, psa_client_id, psa_security_lifecycle,
-        psa_implementation_id, psa_implementation_id_len, measurement_type,
-        signer_id, SIGNER_ID_LEN, psa_instance_id, INSTANCE_ID_LEN, nonce,
-        nonce_sz, measurement_value, TEE_SHA256_HASH_SIZE, buffuer_for_cbor);
+        psa_implementation_id, psa_implementation_id_len, components,
+        sizeof(components) / sizeof(components[0]), psa_instance_id,
+        INSTANCE_ID_LEN, nonce, nonce_sz, buffuer_for_cbor);
     if (UsefulBuf_IsNULLC(ubc_cbor_evidence)) {
         DMSG("Failed to encode evidence to CBOR");
         free(heap_cbor);

--- a/provisoning/README-j.md
+++ b/provisoning/README-j.md
@@ -86,3 +86,24 @@ veraison clear-stores
 ```
 
 引数を省略した場合は `qemu` が使われます。
+
+## 参照値のオフライン計算
+
+`data/comid-psa-refval-*.json` に登録する `measurement-value` のダイジェストは、
+ビルド成果物から直接計算できます。イメージの起動やデバッグログの取得は不要です
+(i.MX の本番ビルドはコアログレベルが 0 のため、オフライン計算が唯一の取得手段です):
+
+```sh
+# ARoT(TA の測定値): 署名済み .ta または TA の ELF を渡す
+./compute-arot-refval.py path/to/<uuid>.ta
+
+# PRoT(OP-TEE OS の測定値): コアの ELF を渡す
+./compute-prot-refval.py path/to/tee.elf
+```
+
+それぞれ、対応する measurement に記載する `sha-256;<base64>` ダイジェストを
+出力します。どちらも QEMU 上で、PTA が出力する実行時測定値と一致することを
+検証済みです。PRoT の値はビルド固有(OP-TEE がビルド日時をハッシュ対象の
+`.rodata` に埋め込むため)なので、リリースビルドごとに再計算・再登録して
+ください。ARoT の値は TA バイナリが変わったときだけ変わります。
+`pyelftools` が必要です(`pip install pyelftools`)。

--- a/provisoning/README.md
+++ b/provisoning/README.md
@@ -88,3 +88,25 @@ You can automatically execute the above steps by running the following command.
 ```
 
 If you omit the argument, `qemu` is used.
+
+## Computing the Reference Values Offline
+
+The `measurement-value` digests registered in `data/comid-psa-refval-*.json`
+can be computed directly from the build artifacts — no need to boot the image
+or capture debug logs (on i.MX production builds the core log level is 0, so
+the offline computation is the only way):
+
+```sh
+# ARoT (the TA measurement): pass the signed .ta or the TA ELF
+./compute-arot-refval.py path/to/<uuid>.ta
+
+# PRoT (the OP-TEE OS measurement): pass the core ELF
+./compute-prot-refval.py path/to/tee.elf
+```
+
+Each prints the `sha-256;<base64>` digest to put into the corresponding
+measurement entry. Both were verified on QEMU to be identical to the runtime
+measurements emitted by the PTA. Note the PRoT value is build-specific
+(OP-TEE embeds the build timestamp in the hashed `.rodata`), so recompute and
+re-provision it for every released build; the ARoT value only changes when
+the TA binary changes. Requires `pyelftools` (`pip install pyelftools`).

--- a/provisoning/compute-arot-refval.py
+++ b/provisoning/compute-arot-refval.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Compute the ARoT reference measurement-value from a TA binary.
+
+This is the offline equivalent of the remote attestation PTA's
+get_hash_ta_memory(): SHA-256 over the calling TA's read-only memory
+regions as mapped by ldelf, which are
+
+  - the first page of the TA ELF (ldelf maps file offset 0, 4096 bytes,
+    read-only: ELF header + program headers, see ldelf init_elf()), and
+  - every read-only PT_LOAD segment: file content zero-padded to the
+    page-rounded memory size.
+
+The regions are hashed smallest-first (ties broken by content), matching
+the runtime cmp_regions() ordering, so the result is independent of TA
+ASLR. Verified against the runtime measurement on QEMU.
+
+Accepts either the raw TA ELF (*.elf / *.stripped.elf) or the signed
+*.ta file (the signed header is skipped automatically).
+
+Usage:
+    ./compute-arot-refval.py path/to/<uuid>.ta
+
+Requires: pyelftools (pip install pyelftools)
+"""
+import base64
+import hashlib
+import io
+import sys
+
+from elftools.elf.elffile import ELFFile
+
+PAGE = 4096
+
+
+def elf_bytes(path):
+    """Return the ELF image contained in path (skip a .ta signed header)."""
+    data = open(path, "rb").read()
+    if data[:4] == b"\x7fELF":
+        return data
+    off = data.find(b"\x7fELF")
+    if off < 0:
+        raise SystemExit(f"error: no ELF image found in {path}")
+    return data[off:]
+
+
+def roundup(n, align=PAGE):
+    return (n + align - 1) & ~(align - 1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 1
+
+    data = elf_bytes(sys.argv[1])
+    elf = ELFFile(io.BytesIO(data))
+
+    # Region 1: the ELF header page mapped read-only by ldelf (file page 0)
+    regions = [data[:PAGE].ljust(PAGE, b"\0")]
+
+    # Read-only PT_LOAD segments, zero-padded to the mapped (page-rounded
+    # memsz) size. Writable segments are not part of the measurement.
+    ro_ranges = []
+    for seg in elf.iter_segments():
+        if seg["p_type"] != "PT_LOAD" or seg["p_flags"] & 0x2:  # PF_W
+            continue
+        content = data[seg["p_offset"]:seg["p_offset"] + seg["p_filesz"]]
+        regions.append(content.ljust(roundup(seg["p_memsz"]), b"\0"))
+        ro_ranges.append((seg["p_vaddr"], seg["p_vaddr"] + seg["p_memsz"]))
+
+    # The measurement is only load-address-independent if no relocation
+    # targets a read-only segment; warn if one does.
+    for sec in elf.iter_sections():
+        if not sec.name.startswith(".rela"):
+            continue
+        for rel in sec.iter_relocations():
+            off = rel["r_offset"]
+            if any(lo <= off < hi for lo, hi in ro_ranges):
+                print(f"warning: relocation targets read-only segment "
+                      f"(offset 0x{off:x}); the runtime measurement may "
+                      f"not match this offline value", file=sys.stderr)
+                break
+
+    # Hash smallest-first, ties by content (matches runtime cmp_regions())
+    regions.sort(key=lambda r: (len(r), r))
+
+    h = hashlib.sha256()
+    for r in regions:
+        h.update(r)
+
+    digest = h.digest()
+    print(f"ARoT measurement-value (b64): {base64.b64encode(digest).decode()}")
+    print(f"ARoT measurement-value (hex): {digest.hex()}")
+    print(f'comid digests entry: "sha-256;{base64.b64encode(digest).decode()}"')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/provisoning/compute-prot-refval.py
+++ b/provisoning/compute-prot-refval.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Compute the PRoT reference measurement-value from a tee.elf build artifact.
+
+This is the offline equivalent of the remote attestation PTA's
+get_hash_tee_memory(): SHA-256 over the OP-TEE core's immutable memory,
+hashed in the same order as the runtime measurement:
+
+    [__text_start,      __text_data_start)
+    [__text_data_end,   __text_end)
+    (pager text sections, if present)
+    [__rodata_start,    __rodata_end)
+    (pager rodata sections, if present)
+
+Because the PRoT measurement-value is build-specific (core_v_str embeds the
+build timestamp), the reference value must be recomputed and re-provisioned
+for every released build. This script makes that possible without booting
+the image or raising the core log level.
+
+Usage:
+    ./compute-prot-refval.py path/to/tee.elf
+
+Output: the base64 measurement-value to put in the comid reference value
+(digests entry: "sha-256;<base64>").
+
+Requires: pyelftools (pip install pyelftools)
+"""
+import base64
+import hashlib
+import sys
+
+from elftools.elf.elffile import ELFFile
+
+
+def load_symbols(elf):
+    syms = {}
+    for secname in (".symtab", ".dynsym"):
+        sec = elf.get_section_by_name(secname)
+        if sec is None:
+            continue
+        for sym in sec.iter_symbols():
+            syms[sym.name] = sym["st_value"]
+    return syms
+
+
+def read_va_range(elf, start, end):
+    """Read [start, end) virtual addresses from the ELF LOAD segments."""
+    if end <= start:
+        return b""
+    out = bytearray(end - start)
+    covered = 0
+    for seg in elf.iter_segments():
+        if seg["p_type"] != "PT_LOAD":
+            continue
+        seg_va = seg["p_vaddr"]
+        seg_filesz = seg["p_filesz"]
+        lo = max(start, seg_va)
+        hi = min(end, seg_va + seg_filesz)
+        if lo >= hi:
+            continue
+        data = seg.data()
+        out[lo - start:hi - start] = data[lo - seg_va:hi - seg_va]
+        covered += hi - lo
+    if covered != end - start:
+        raise SystemExit(
+            f"error: VA range 0x{start:x}..0x{end:x} not fully covered by "
+            f"LOAD segments ({covered}/{end - start} bytes)")
+    return bytes(out)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 1
+    path = sys.argv[1]
+
+    with open(path, "rb") as f:
+        elf = ELFFile(f)
+        syms = load_symbols(elf)
+
+        def addr(name):
+            if name not in syms:
+                raise SystemExit(f"error: symbol {name} not found in {path}")
+            return syms[name]
+
+        # Same span order as get_hash_tee_memory()
+        spans = [
+            (addr("__text_start"), addr("__text_data_start")),
+            (addr("__text_data_end"), addr("__text_end")),
+        ]
+        if "__text_init_start" in syms:  # CFG_WITH_PAGER=y builds only
+            spans += [
+                (addr("__text_init_start"), addr("__text_init_end")),
+                (addr("__text_pageable_start"), addr("__text_pageable_end")),
+            ]
+        spans.append((addr("__rodata_start"), addr("__rodata_end")))
+        if "__rodata_init_start" in syms:  # CFG_WITH_PAGER=y builds only
+            spans += [
+                (addr("__rodata_init_start"), addr("__rodata_init_end")),
+                (addr("__rodata_pageable_start"),
+                 addr("__rodata_pageable_end")),
+            ]
+
+        h = hashlib.sha256()
+        for start, end in spans:
+            h.update(read_va_range(elf, start, end))
+
+    digest = h.digest()
+    print(f"PRoT measurement-value (b64): {base64.b64encode(digest).decode()}")
+    print(f"PRoT measurement-value (hex): {digest.hex()}")
+    print(f'comid digests entry: "sha-256;{base64.b64encode(digest).decode()}"')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/provisoning/data/comid-psa-refval-imx.json
+++ b/provisoning/data/comid-psa-refval-imx.json
@@ -42,6 +42,20 @@
                 "sha-256;v0A0kWI5jq4tGIGZf+o4ujdq/udWwLgzfrOc2XOb13A="
               ]
             }
+          },
+          {
+            "key": {
+              "type": "psa.refval-id",
+              "value": {
+                "label": "PRoT",
+                "signer-id": "427zIO3QE+zwfmqkGRPzdhocbmeEF9Bpn5Lk/mBzgf4="
+              }
+            },
+            "value": {
+              "digests": [
+                "sha-256;UsHZbTgZfIUT3ga7FuAaKn/PnGO2WgpvZp1eM2b82oY="
+              ]
+            }
           }
         ]
       }

--- a/provisoning/data/comid-psa-refval-imx.json
+++ b/provisoning/data/comid-psa-refval-imx.json
@@ -39,7 +39,7 @@
             },
             "value": {
               "digests": [
-                "sha-256;v0A0kWI5jq4tGIGZf+o4ujdq/udWwLgzfrOc2XOb13A="
+                "sha-256;FjIXXyuEaEG2FsLTRZjCck573aBBlnJT0sed9M9nRwA="
               ]
             }
           },


### PR DESCRIPTION
## Summary

Adds a second PSA software component (`measurement-type: "PRoT"`) reporting the OP-TEE OS version, alongside the existing `ARoT` (TA) component. `implementation-id` and `signer-id` are unchanged.

- `hash.c`: `get_hash_tee_memory()` — SHA-256 of the core `.text` + `.rodata` (mirrors the upstream attestation PTA).
- `cbor.{c,h}`: software components passed as an array; optional `version` (#4) field emitted.
- `remote_attestation.c`: OS version taken from `core_v_str` (e.g. `"4.6.0"`); builds ARoT + PRoT.

## Reference values: computed offline, registered per build

- `provisoning/compute-prot-refval.py tee.elf` — PRoT. Build-specific (the build timestamp is part of the hashed `.rodata`), so recompute per release. Yocto builds are reproducible (bit-identical `tee.elf` for the same source), so same-source rebuilds keep the value valid.
- `provisoning/compute-arot-refval.py <uuid>.ta` — ARoT (ELF-header page + read-only PT_LOAD segments, smallest-first). No first device run needed; required on i.MX production builds, which print no core trace.

Both verified on QEMU: script output == runtime measurement.

## Verification (QEMU E2E)

- `ear.status: affirming`, `executables: 2`, components `[ARoT, PRoT(version="4.6.0-dev")]`.
- PRoT matching active: correct reference value → `affirming`; wrong value (simulated build change) → `warning`.

## Scope

The RFC 9783 claim fixes this work was based on are already in `main` (#6), so this PR contains only the PRoT component, the offline reference-value scripts and registered i.MX values, docs, and two small docker build-context exclusions (`secure-boot-out/`, `container-imx/yocto/`).