### PR TITLE
secure-boot: fix mkimage_imx8 execution inside the sign container

### DIFF
--- a/attester/container-imx/.dockerignore
+++ b/attester/container-imx/.dockerignore
@@ -1,0 +1,2 @@
+secure-boot-out/
+yocto/

--- a/attester/container-imx/secure-boot-sign-imx-boot.sh
+++ b/attester/container-imx/secure-boot-sign-imx-boot.sh
@@ -95,6 +95,7 @@ set -x
 docker run --rm \
   --user 0:0 \
   -v "$YOCTO_DIR_ABS:/yocto" \
+  -v "$YOCTO_DIR_ABS:$YOCTO_DIR_ABS" \
   -v "$OUT_DIR_ABS:/out" \
   $CST_MOUNT_ARGS \
   -e CST_PASS="$CST_PASS" \

--- a/attester/container-imx/secure-boot-sign-kernel.sh
+++ b/attester/container-imx/secure-boot-sign-kernel.sh
@@ -84,6 +84,7 @@ set -x
 docker run --rm \
   --user 0:0 \
   -v "$YOCTO_DIR_ABS:/yocto" \
+  -v "$YOCTO_DIR_ABS:$YOCTO_DIR_ABS" \
   -v "$OUT_DIR_ABS:/out" \
   $CST_MOUNT_ARGS \
   -e CST_PASS="$CST_PASS" \


### PR DESCRIPTION
Two small fixes to the i.MX8MP secure-boot signing flow, independent of the attestation work.

- **Same-path bind mount**: `secure-boot-sign-imx-boot.sh` / `secure-boot-sign-kernel.sh` run `mkimage_imx8` from the Yocto work tree inside the signing container. That binary's ELF interpreter is the uninative loader at an absolute host path (`…/sysroots-uninative/…/ld-linux-*`), so with the tree mounted only at `/yocto` it cannot execute. The tree is now additionally mounted at its host-absolute path (`-v "$YOCTO_DIR_ABS:$YOCTO_DIR_ABS"`).
- **`.dockerignore`** for `attester/container-imx`: exclude `secure-boot-out/` and `yocto/` from the docker build context of `Dockerfile.yocto`.

Verified on the i.MX8MP EVK signing flow used for recent device builds (HAB-signed images boot with a closed device configuration).